### PR TITLE
upd GetGearItemPrefab to use newer code

### DIFF
--- a/Patches.cs
+++ b/Patches.cs
@@ -80,7 +80,7 @@ namespace CanneryManufacturingDLC
 				}
 			}
 
-			private static GearItem GetGearItemPrefab(string name) => Resources.Load(name).Cast<GameObject>().GetComponent<GearItem>();
+			private static GearItem GetGearItemPrefab(string name) => GearItem.LoadGearItemPrefab(name).GetComponent<GearItem>();
 		}
 
 


### PR DESCRIPTION
Ive noticed alot of mods using this method and everyone of them throws a null ref. This update should fix that